### PR TITLE
refactor/card

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,46 +1,27 @@
-import * as React from 'react';
+import React from 'react';
 import {useNavigate} from 'react-router-dom';
-import {Teams, UserData} from 'types';
-import {Container} from './styles';
+import {CardItem} from 'types';
+import {Container, InfoText, Title} from './styles';
 
-interface Props {
-    id?: string;
-    url?: string;
-    columns: Array<{
-        key: string;
-        value: string;
-    }>;
-    hasNavigation?: boolean;
-    navigationProps?: UserData | Teams;
-}
-
-const Card = ({
-    id,
-    columns,
-    url,
-    hasNavigation = true,
-    navigationProps = null,
-}: Props): JSX.Element => {
+const Card = ({id, title, name, location, navigateTo, navigationProps}: CardItem) => {
     const navigate = useNavigate();
+
+    const onCardClick = e => {
+        e.preventDefault();
+        if (navigateTo) {
+            navigate(navigateTo, {state: navigationProps});
+        }
+    };
 
     return (
         <Container
             data-testid={`cardContainer-${id}`}
-            hasNavigation={hasNavigation}
-            onClick={(e: Event) => {
-                if (hasNavigation) {
-                    navigate(url, {
-                        state: navigationProps,
-                    });
-                }
-                e.preventDefault();
-            }}
+            onClick={onCardClick}
+            navigateTo={!!navigateTo}
         >
-            {columns.map(({key: columnKey, value}) => (
-                <p key={columnKey}>
-                    <strong>{columnKey}</strong>&nbsp;{value}
-                </p>
-            ))}
+            <Title data-testid="cardTitle">{title}</Title>
+            <InfoText data-testid="cardName">{name}</InfoText>
+            {location ? <InfoText data-testid="cardLocation">📍{location}</InfoText> : null}
         </Container>
     );
 };

--- a/src/components/Card/styles.ts
+++ b/src/components/Card/styles.ts
@@ -1,15 +1,32 @@
 import styled from 'styled-components';
 
-export const Container = styled.div<{hasNavigation: boolean}>`
+export const Container = styled.div<{navigateTo: boolean}>`
     display: flex;
-    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    border: 1px solid black;
-    background: #ddd;
-    padding: 20px;
+    flex-direction: column;
+    padding: 0.8rem 2rem;
+    gap: 1rem;
+    flex-shrink: 0;
     width: 250px;
-    max-height: 200px;
-    cursor: ${props => (props.hasNavigation ? 'pointer' : 'default')};
-    margin: 5px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    background: #5a6af9;
+    box-shadow: 0px 4px 14px 0px #5a6af9;
+    color: white;
+    cursor: ${props => (props.navigateTo ? 'pointer' : 'default')};
+`;
+
+export const Title = styled.h3`
+    color: #fff;
+    text-align: center;
+    font-size: 1rem;
+    font-family: Inter;
+    font-weight: 600;
+`;
+
+export const InfoText = styled.p`
+    color: #fff;
+    text-align: center;
+    font-size: 1rem;
+    font-family: Inter;
 `;

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,29 +1,32 @@
-import * as React from 'react';
-import {ListItem} from 'types';
+import React from 'react';
+
+import {CardItem} from 'types';
+
 import Card from '../Card';
 import {Spinner} from '../Spinner';
+
 import {Container} from './styles';
 
-interface Props {
-    items?: ListItem[];
-    hasNavigation?: boolean;
-    isLoading: string;
+interface ListProps {
+    items: CardItem[];
+    isLoading: boolean;
 }
 
-const List = ({items, hasNavigation = true, isLoading}: Props) => {
+const List = ({items, isLoading}: ListProps) => {
     return (
         <Container>
             {isLoading && <Spinner />}
             {!isLoading &&
-                items.map(({url, id, columns, navigationProps}, index) => {
+                items.map(({id, title, name, location, navigateTo, navigationProps}, index) => {
                     return (
                         <Card
                             key={`${id}-${index}`}
                             id={id}
-                            columns={columns}
+                            name={name}
+                            title={title}
+                            location={location}
+                            navigateTo={navigateTo}
                             navigationProps={navigationProps}
-                            hasNavigation={hasNavigation}
-                            url={url}
                         />
                     );
                 })}

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,44 +1,45 @@
-import * as React from 'react';
-import {ListItem, Teams as TeamsList} from 'types';
-import {getTeams as fetchTeams} from '../api';
+import React, {useEffect, useState} from 'react';
+import {Team} from 'types';
+
+import {getTeams} from '../api';
+
 import Header from '../components/Header';
 import List from '../components/List';
 import {Container} from '../components/GlobalComponents';
 
-var MapT = (teams: TeamsList[]) => {
-    return teams.map(team => {
-        var columns = [
-            {
-                key: 'Name',
-                value: team.name,
-            },
-        ];
-        return {
-            id: team.id,
-            url: `/team/${team.id}`,
-            columns,
-            navigationProps: team,
-        } as ListItem;
-    });
-};
-
 const Teams = () => {
-    const [teams, setTeams] = React.useState<any>([]);
-    const [isLoading, setIsLoading] = React.useState<any>(true);
+    const [teams, setTeams] = useState<Team[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
 
-    React.useEffect(() => {
-        const getTeams = async () => {
-            const response = await fetchTeams();
+    const formatTeamsToCards = (teamList: Team[]) => {
+        if (teamList === undefined) {
+            return [];
+        }
+
+        return teamList.map(team => {
+            return {
+                id: team.id,
+                title: 'Team Name',
+                name: team.name,
+                navigateTo: `/team/${team.id}`,
+                navigationProps: team,
+            };
+        });
+    };
+
+    useEffect(() => {
+        const fetchTeams = async () => {
+            const response = await getTeams();
             setTeams(response);
             setIsLoading(false);
         };
-        getTeams();
+        fetchTeams();
     }, []);
 
     return (
         <Container>
             <Header title="Teams" showBackButton={false} />
-            <List items={MapT(teams)} isLoading={isLoading} />
+            <List items={formatTeamsToCards(teams)} isLoading={isLoading} />
         </Container>
     );
 };

--- a/src/pages/UserOverview.tsx
+++ b/src/pages/UserOverview.tsx
@@ -1,36 +1,22 @@
-import * as React from 'react';
+import React from 'react';
 import {useLocation} from 'react-router-dom';
-import {UserData} from 'types';
+
 import Card from '../components/Card';
 import {Container} from '../components/GlobalComponents';
 import Header from '../components/Header';
 
-var mapU = (user: UserData) => {
-    var columns = [
-        {
-            key: 'Name',
-            value: `${user.firstName} ${user.lastName}`,
-        },
-        {
-            key: 'Display Name',
-            value: user.displayName,
-        },
-        {
-            key: 'Location',
-            value: user.location,
-        },
-    ];
-    return <Card columns={columns} hasNavigation={false} navigationProps={user} />;
-};
-
 const UserOverview = () => {
     const location = useLocation();
+    const name = `${location.state.firstName} ${location.state.lastName}`;
     return (
         <Container>
-            <Header
-                title={`User ${location.state.firstName} ${location.state.lastName}`}
+            <Header title={`User ${location.state.firstName} ${location.state.lastName}`} />
+            <Card
+                id={location.state.id}
+                title=""
+                name={`${name} (${location.state.displayName})`}
+                location={location.state.location}
             />
-            {mapU(location.state)}
         </Container>
     );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export interface Teams {
+export interface Team {
     id: string;
     name: string;
 }
@@ -18,14 +18,11 @@ export interface UserData {
     avatar: string;
 }
 
-export interface ListItemColumn {
-    key: string;
-    value: string;
-}
-
-export interface ListItem {
+export interface CardItem {
     id: string;
-    url?: string;
-    columns: Array<ListItemColumn>;
-    navigationProps?: UserData | Teams;
+    title: string;
+    name: string;
+    location?: string;
+    navigateTo?: string;
+    navigationProps?: UserData | Team;
 }


### PR DESCRIPTION
On this PR the focus was the Card component. As we know what are the props that we are interested, we can use it as props and remove the "columns" prop, that was a bit confused.

- Remove `columns` prop from card (now use title, name and location).
- Changed types names (ListItem to CardItem and Teams to Team)
- Styled Card with purple color.
- Remove `hasNavigation` from List component, if I pass an url it is implicit that it has navigation, so change the prop to `navigateTo`.

I have also made some changes on pages that uses the Card component:

**Teams Page**
- Refactor the `MapT` function to a more cleaner and understandable function, called `formatTeamsToCards`
- Fix the variables types, remove `any` types.

**Team Overview**
- Remove `pageData` variable, separate each data on a unique state (`teamLead` and `teamMembers`).
- Refactor map functions from `mapTLead` and `mapArray` to `teamLeadCard` and `formatMembersToCards`, as I removed the columns prop from Card, the function became more cleaner.
- Improve api requests, remove the for loop and use Promise.all to make members requests.

**User Overview**

- Use a single card component, remove `mapU` function.