### PR TITLE
feat/tests

### DIFF
--- a/src/components/Card/__tests__/testCard.tsx
+++ b/src/components/Card/__tests__/testCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
-import {Teams} from 'types';
 import Card from '..';
 
 const mockUseNavigate = jest.fn();
@@ -11,55 +10,54 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('Card', () => {
-    it('should render card with single column', () => {
-        var columns = [{key: 'columnKey', value: 'columnValue'}];
-        render(<Card columns={columns} />);
+    it('should render card with Title and Name', () => {
+        render(<Card id="card-test-id" title="Title Test" name="Name Test" />);
 
-        expect(screen.getByText('columnKey')).toBeInTheDocument();
-        expect(screen.getByText('columnValue')).toBeInTheDocument();
+        expect(screen.getByTestId('cardContainer-card-test-id')).toBeInTheDocument();
+        expect(screen.getByText('Title Test')).toBeInTheDocument();
+        expect(screen.getByText('Name Test')).toBeInTheDocument();
     });
 
-    it('should render card with multiple columns', () => {
-        var columns = [
-            {key: 'columnKey1', value: 'columnValue1'},
-            {key: 'columnKey2', value: 'columnValue2'},
-            {key: 'columnKey3', value: 'columnValue3'},
-            {key: 'columnKey4', value: ''},
-        ];
-        render(<Card columns={columns} />);
+    it('should render card with Title, Name and Location (all texts possible)', () => {
+        render(
+            <Card id="card-test-id" title="Title Test" name="Name Test" location="Location Test" />
+        );
 
-        expect(screen.getByText('columnKey1')).toBeInTheDocument();
-        expect(screen.getByText('columnValue1')).toBeInTheDocument();
-        expect(screen.getByText('columnKey2')).toBeInTheDocument();
-        expect(screen.getByText('columnValue2')).toBeInTheDocument();
-        expect(screen.getByText('columnKey3')).toBeInTheDocument();
-        expect(screen.getByText('columnValue3')).toBeInTheDocument();
-        expect(screen.getByText('columnKey4')).toBeInTheDocument();
+        expect(screen.getByTestId('cardContainer-card-test-id')).toBeInTheDocument();
+
+        expect(screen.getByTestId('cardTitle')).toBeInTheDocument();
+        expect(screen.getByText('Title Test')).toBeInTheDocument();
+
+        expect(screen.getByTestId('cardName')).toBeInTheDocument();
+        expect(screen.getByText('Name Test')).toBeInTheDocument();
+
+        expect(screen.getByTestId('cardLocation')).toBeInTheDocument();
+        expect(screen.getByText('📍Location Test')).toBeInTheDocument();
     });
 
-    it('should navigate when card is clicked and navigation is enabled', () => {
-        const navProps = {
-            id: '1',
-            name: 'Team 1',
-        } as Teams;
+    it('should navigate when card is clicked and has a navigation link (navigationTo)', () => {
+        render(<Card id="card-test-id" title="Title Test" name="Name Test" navigateTo="path" />);
+
+        fireEvent.click(screen.getByTestId('cardContainer-card-test-id'));
+
+        expect(mockUseNavigate).toHaveBeenCalledWith('path', {state: undefined});
+    });
+
+    it('should navigate (with state data) when card is clicked and has a navigation link (navigationTo)', () => {
+        const navProps = {id: '1', name: 'Test'};
+
         render(
             <Card
-                columns={[{key: 'columnKey', value: 'columnValue'}]}
-                url="path"
+                id="card-test-id"
+                title="Title Test"
+                name="Name Test"
+                navigateTo="path"
                 navigationProps={navProps}
             />
         );
 
-        fireEvent.click(screen.getByText('columnKey'));
+        fireEvent.click(screen.getByTestId('cardContainer-card-test-id'));
 
         expect(mockUseNavigate).toHaveBeenCalledWith('path', {state: navProps});
-    });
-
-    it('should not navigate when card is clicked and navigation is disabled', () => {
-        render(<Card columns={[{key: 'columnKey', value: 'columnValue'}]} hasNavigation={false} />);
-
-        fireEvent.click(screen.getByText('columnKey'));
-
-        expect(mockUseNavigate).not.toHaveBeenCalled();
     });
 });

--- a/src/components/Header/__tests__/testHeader.tsx
+++ b/src/components/Header/__tests__/testHeader.tsx
@@ -10,18 +10,6 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('Header', () => {
-    beforeAll(() => {
-        jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-        jest.clearAllTimers();
-    });
-
-    afterAll(() => {
-        jest.useRealTimers();
-    });
-
     it('should render header', () => {
         render(<Header title="Header" />);
 
@@ -45,6 +33,6 @@ describe('Header', () => {
 
         fireEvent.click(screen.getByRole('button'));
 
-        expect(mockUseNavigate).toHaveBeenCalled();
+        expect(mockUseNavigate).toHaveBeenCalledWith(-1);
     });
 });

--- a/src/components/List/__tests__/testList.tsx
+++ b/src/components/List/__tests__/testList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {render, screen} from '@testing-library/react';
+import {ICardItem} from 'types';
 import List from '..';
 
 jest.mock('react-router-dom', () => ({
@@ -11,63 +12,59 @@ describe('List', () => {
     it('should render spinner and not render items when it is loading', () => {
         const items = [
             {
-                id: '1',
-                columns: [
-                    {
-                        key: 'columnKey1',
-                        value: 'columnValue1',
-                    },
-                ],
+                id: 'test-id',
+                title: 'Test Title',
+                name: 'Test Name',
+                location: 'Location Test',
+                navigateTo: 'path',
+                navigationProps: {id: '1', name: 'Test'},
             },
-        ];
+        ] as ICardItem[];
         render(<List isLoading items={items} />);
 
         expect(screen.getByTestId('spinner')).toBeInTheDocument();
-        expect(screen.queryByTestId('cardContainer')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('cardContainer-test-id')).not.toBeInTheDocument();
     });
 
     it('should not render spinner and render items when it is not loading', () => {
         const items = [
             {
-                id: '1',
-                columns: [
-                    {
-                        key: 'columnKey1',
-                        value: 'columnValue1',
-                    },
-                ],
+                id: 'test-id',
+                title: 'Test Title',
+                name: 'Test Name',
+                location: 'Location Test',
+                navigateTo: 'path',
+                navigationProps: {id: '1', name: 'Test'},
             },
-        ];
+        ] as ICardItem[];
         render(<List isLoading={false} items={items} />);
 
         expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
-        expect(screen.getByTestId('cardContainer-1')).toBeInTheDocument();
+        expect(screen.getByTestId('cardContainer-test-id')).toBeInTheDocument();
     });
 
-    it('should render multiple card when multiple items', () => {
+    it('should render multiple cards when multiple items is passed', () => {
         const items = [
             {
-                id: '1',
-                columns: [
-                    {
-                        key: 'columnKey1',
-                        value: 'columnValue1',
-                    },
-                ],
+                id: 'test-id-1',
+                title: 'Test Title 1',
+                name: 'Test Name 1',
+                location: 'Location Test 1',
+                navigateTo: 'path',
+                navigationProps: {id: '1', name: 'Test'},
             },
             {
-                id: '2',
-                columns: [
-                    {
-                        key: 'columnKey2',
-                        value: 'columnValue2',
-                    },
-                ],
+                id: 'test-id-2',
+                title: 'Test Title 2',
+                name: 'Test Name 2',
+                location: 'Location Test 2',
+                navigateTo: 'path',
+                navigationProps: {id: '1', name: 'Test'},
             },
         ];
         render(<List isLoading={false} items={items} />);
 
-        expect(screen.getByTestId('cardContainer-1')).toBeInTheDocument();
-        expect(screen.getByTestId('cardContainer-2')).toBeInTheDocument();
+        expect(screen.getByTestId('cardContainer-test-id-1')).toBeInTheDocument();
+        expect(screen.getByTestId('cardContainer-test-id-2')).toBeInTheDocument();
     });
 });

--- a/src/pages/__tests__/testTeamOverview.tsx
+++ b/src/pages/__tests__/testTeamOverview.tsx
@@ -1,54 +1,122 @@
-import * as React from 'react';
-import {render, screen, waitFor} from '@testing-library/react';
-import * as API from '../../api';
+import React from 'react';
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    waitForElementToBeRemoved,
+} from '@testing-library/react';
+import {SWRConfig} from 'swr';
+import userEvent from '@testing-library/user-event';
 import TeamOverview from '../TeamOverview';
+import * as API from '../../api';
+
+const mockUseNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockUseNavigate,
     useLocation: () => ({
-        state: {
-            teamName: 'Some Team',
-        },
+        state: {name: 'Name Test'},
     }),
-    useNavigate: () => ({}),
-    useParams: () => ({
-        teamId: '1',
-    }),
+    useParams: () => {
+        return {
+            teamId: '1001',
+        };
+    },
 }));
 
 describe('TeamOverview', () => {
-    beforeAll(() => {
-        jest.useFakeTimers();
-    });
+    const asyncGetData = jest.spyOn(API, 'getData');
+    const asyncGetUserData = jest.spyOn(API, 'getUserData');
+    const renderTeamOverview = () =>
+        render(
+            <SWRConfig value={{provider: () => new Map()}}>
+                <TeamOverview />
+            </SWRConfig>
+        );
 
-    afterEach(() => {
-        jest.clearAllTimers();
-    });
+    beforeEach(() => {
+        asyncGetData
+            .mockResolvedValue({})
+            .mockResolvedValueOnce({
+                id: '1',
+                teamLeadId: '2',
+                teamMemberIds: ['3', '4', '5'],
+            })
+            .mockResolvedValueOnce({
+                id: '2',
+                firstName: 'Lead',
+                lastName: 'Name',
+                displayName: 'test',
+                location: '',
+                avatar: '',
+            });
 
-    afterAll(() => {
-        jest.useRealTimers();
-    });
-
-    it('should render team overview users', async () => {
-        const teamOverview = {
-            id: '1',
-            teamLeadId: '2',
-            teamMemberIds: ['3', '4', '5'],
-        };
-        const userData = {
-            id: '2',
-            firstName: 'userData',
-            lastName: 'userData',
-            displayName: 'userData',
+        asyncGetUserData.mockResolvedValue({
+            id: '3',
+            firstName: 'FirstName',
+            lastName: 'LastName',
+            displayName: 'test',
             location: '',
             avatar: '',
-        };
-        jest.spyOn(API, 'getTeamOverview').mockImplementationOnce(() => Promise.resolve({} as any));
-        jest.spyOn(API, 'getUserData').mockImplementationOnce(() => Promise.resolve({} as any));
+        });
+    });
 
-        render(<TeamOverview />);
+    it('should render page with team name from location state and spinner while loading', async () => {
+        renderTeamOverview();
 
         await waitFor(() => {
-            expect(screen.queryAllByText('userData')).toHaveLength(4);
+            expect(screen.getByText('Team Name Test')).toBeInTheDocument();
         });
+        expect(screen.getByTestId('spinner')).toBeInTheDocument();
+
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'));
+    });
+
+    it('should call all API endpoints and render the team member and lead cards', async () => {
+        renderTeamOverview();
+
+        await waitFor(() => {
+            expect(asyncGetData).toHaveBeenCalledWith('teams/1001');
+        });
+
+        await waitFor(() => {
+            expect(asyncGetUserData).toHaveBeenCalledTimes(3);
+        });
+
+        expect(asyncGetUserData).toHaveBeenCalledWith('3');
+        expect(asyncGetUserData).toHaveBeenCalledWith('4');
+        expect(asyncGetUserData).toHaveBeenCalledWith('5');
+
+        await waitFor(() => {
+            expect(asyncGetData).toHaveBeenCalledWith('users/2');
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Lead Name (test)')).toBeInTheDocument();
+        expect(screen.queryAllByText('FirstName LastName (test)')).toHaveLength(3);
+    });
+
+    it('should filter results of team members when name is searched', async () => {
+        renderTeamOverview();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('search-icon')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('search-icon'));
+        const input = screen.getByTestId('search');
+
+        await userEvent.type(input, 'Lead');
+
+        await waitFor(() => {
+            expect(screen.getByText('Lead Name (test)')).toBeInTheDocument();
+        });
+
+        expect(screen.queryAllByText('FirstName LastName (test)')).toHaveLength(0);
     });
 });

--- a/src/pages/__tests__/testUserOverview.tsx
+++ b/src/pages/__tests__/testUserOverview.tsx
@@ -18,8 +18,7 @@ describe('UserOverview', () => {
     it('should render UserOverview', () => {
         render(<UserOverview />);
 
-        expect(screen.getByText('Test User')).toBeInTheDocument();
-        expect(screen.getByText('userName')).toBeInTheDocument();
-        expect(screen.getByText('location')).toBeInTheDocument();
+        expect(screen.getByText('Test User (userName)')).toBeInTheDocument();
+        expect(screen.getByText('📍location')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
On this PR I have refactored all implemented tests, covering possibilities that was not covered and making it more readable and cleaner.

I had to use `SWRConfig` element in pages tests so that the cache generate by it could be reset for each render.

**Tests**
- Card, Header, List, Spinner and TextInput components
- Teams, TeamOverview and UserOverview pages

All scenarios is described on `it` function.